### PR TITLE
Fixed number rounding in `NP.VAT()` in use 0% VAT

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -4310,7 +4310,7 @@ NP.VAT = function(percentage, decimals, includedVAT) {
 	if (includedVAT === undefined)
 		includedVAT = true;
 
-	return !percentage || !num ? num : includedVAT ? (num / ((percentage / 100) + 1)).round(decimals) : (num * ((percentage / 100) + 1)).round(decimals);
+	return !percentage || !num ? num.round(decimals) : includedVAT ? (num / ((percentage / 100) + 1)).round(decimals) : (num * ((percentage / 100) + 1)).round(decimals);
 };
 
 NP.discount = function(percentage, decimals) {


### PR DESCRIPTION
var n1 = 10.948283;
var n2 = 0.43333421;
var n3 = 5;

console.log(n1.VAT(0, 2));
console.log(n2.VAT(20, 2));
console.log(n3.VAT(20, 2));

// New
10.95
0.36
4.17

// Old
10.948283
0.36
4.17