### PR TITLE
NEWPUBLISH & NEWSUBSCRIBE fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,17 +120,15 @@ global.NEWPUBLISH = function(name, value) {
 		value = value.$id;
 	}
 
-	if (F.jsonschemas[value]) {
+	if (!F.tms.publish_cache[name])
 		F.tms.publish_cache[name] = value;
-	} else {
-		// Tries to create from the Total.js Schema
-		var schema = GETSCHEMA(value);
-		if (schema)
-			schema.toJSONSchema();
-		else
-			throw new Error('JSON schema "' + value + '" not found.');
-	}
 
+	// Tries to create from the Total.js Schema
+	var schema = GETSCHEMA(value);
+	if (schema)
+		schema.toJSONSchema();
+	else
+		throw new Error('JSON schema "' + value + '" not found.');
 };
 
 global.NEWSUBSCRIBE = function(name, value) {
@@ -145,17 +143,15 @@ global.NEWSUBSCRIBE = function(name, value) {
 		value = value.$id;
 	}
 
-	if (F.jsonschemas[value])
+	if (!F.tms.subscribe_cache[name])
 		F.tms.subscribe_cache[name] = value;
-	else {
-		// Tries to create from the Total.js Schema
-		var schema = GETSCHEMA(value);
-		if (schema)
-			schema.toJSONSchema();
-		else
-			throw new Error('JSON schema "' + value + '" not found.');
-	}
 
+	// Tries to create from the Total.js Schema
+	var schema = GETSCHEMA(value);
+	if (schema)
+		schema.toJSONSchema();
+	else
+		throw new Error('JSON schema "' + value + '" not found.');
 };
 
 global.PUBLISH = function(name, value) {


### PR DESCRIPTION
Fixed problem with first registration of schema usage in NEWPUBLISH and NEWSUBSCRIBE.

Example:
```
// not registered in TMS (JSONSchema was created from Total.js Schema, but wasn't registered for future usage.)
NEWPUBLISH('host_created', 'Hosts/Create');

// Registered in TMS
NEWSUBSCRIBE('host_create', 'Hosts/Create');
```

**Tested - working properly**