### PR TITLE
added check for existance of this.uri

### DIFF
--- a/index.js
+++ b/index.js
@@ -15960,7 +15960,7 @@ function extend_request(PROTO) {
 	Object.defineProperty(PROTO, 'query', {
 		get: function() {
 			if (!this._querydata) {
-				this._querydata = this.uri.query ? DEF.parsers.urlencoded(this.uri.query) : {};
+				this._querydata = this.uri && this.uri.query ? DEF.parsers.urlencoded(this.uri.query) : {};
 			}
 			return this._querydata;
 		},


### PR DESCRIPTION
If you want to use express to create a custom webserver, following error pops up:
`TypeError: Cannot read property 'query' of undefined`

In --servicemode this error is now shown.