### PR TITLE
Fix broken links.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,10 +18,10 @@ $ npm install -g total4
 Please support the framework on social networks.
 
 - [Follow Total.js on Gitter](https://gitter.im/totaljs/framework)
-- [Follow Total.js on GitHub](https://github.com/totaljs/framework)
+- [Follow Total.js on GitHub](https://github.com/totaljs)
 - [Follow Total.js on Twitter - __@totalframework__](https://twitter.com/totalframework)
 - [Follow Total.js on Facebook](https://www.facebook.com/totaljs.web.framework)
-- [Follow Total.js on LinkedIn](https://www.linkedin.com/groups/totaljs-8109884)
+- [Follow Total.js on LinkedIn](https://www.linkedin.com/company/total-avengers/)
 
 ## Contact
 


### PR DESCRIPTION
1. Follow Total.js on GitHub link was pointing to 
Total.js framework v3, so it's being changed to
Total.js's organization page instead.

2. LinkedIn link was broken. So, this commit
replaces it with the correct link which is:
https://www.linkedin.com/company/total-avengers/

By the way, all other links on readme.md are alive :)