### PR TITLE
Allow importing node built-in modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -2630,6 +2630,7 @@ F.callback_redirect = function(url) {
 var modules = { buffer: 1, child_process: 1, process: 1, fs: 1, events: 1, http: 1, https: 1, http2: 1, util: 1, net: 1, os: 1, path: 1, punycode: 1, readline: 1, repl: 1, stream: 1, string_decoder: 1, tls: 1, trace_events: 1, tty: 1, dgram: 1, url: 1, v8: 1, vm: 1, wasi: 1, worker_threads: 1, zlib: 1, crypto: 1 };
 
 F.require = function(path) {
+	if (path.startsWith("node:") return require(path);
 	return modules[path] ? require(path) : CONF.node_modules && CONF.node_modules[0] === '~' ? require(Path.join(CONF.node_modules.substring(1), path)) : require(Path.join(F.directory, CONF.node_modules, path));
 };
 


### PR DESCRIPTION
### TL;DR
The current list of `modules` (line 2630) is outdated and somewhat insecure. This change allows builtin node modules to be imported without issue

### Information
The list of allowed modules was incomplete (missing `assert` module for example). The current best practice is to load built-in modules via `require("node:....")`, to avoid the hijacking of packages through NPM or other repository. 

Therefore this change was made to allow importing of all built-in modules.