### PR TITLE
Improved Array.prototype.async

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -5392,6 +5392,8 @@ AP.async = function(thread, callback, tmp) {
 		thread = 1;
 	} else if (thread === undefined)
 		thread = 1;
+	else if (thread > self.length)
+		thread = self.length;
 
 	if (!tmp) {
 		tmp = {};


### PR DESCRIPTION
If `thread` param is greater than <array>.length then an error is thrown when calling `item(tmp.next);` couple lines bellow.